### PR TITLE
Added cash rules to the blockchain settings

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -133,6 +133,12 @@ uint32_t settings::enabled_forks() const {
     forks |= (bip68 ? rule_fork::bip68_rule : 0);
     forks |= (bip112 ? rule_fork::bip112_rule : 0);
     forks |= (bip113 ? rule_fork::bip113_rule : 0);
+#ifdef BITPRIM_CURRENCY_BCH
+    forks |= rule_fork::cash_low_s_rule;
+    forks |= rule_fork::cash_monolith_opcodes;
+    // Activate this fork rule for the next bitcoin cash release
+    ////forks |= rule_fork::cash_replay_protection;
+#endif
     return forks;
 }
 


### PR DESCRIPTION
The new fork rules must be added to the `forks` variable on the `enabled_forks()` function in order to be used by the node.