### PR TITLE
[BIT-73] activate forkid flag

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -136,6 +136,7 @@ uint32_t settings::enabled_forks() const {
 #ifdef BITPRIM_CURRENCY_BCH
     forks |= rule_fork::cash_low_s_rule;
     forks |= rule_fork::cash_monolith_opcodes;
+    forks |= rule_fork::cash_verify_flags_script_enable_sighash_forkid;
     // Activate this fork rule for the next bitcoin cash release
     ////forks |= rule_fork::cash_replay_protection;
 #endif

--- a/src/validate/validate_input.cpp
+++ b/src/validate/validate_input.cpp
@@ -54,7 +54,9 @@ uint32_t validate_input::convert_flags(uint32_t native_forks)
 
 #ifdef BITPRIM_CURRENCY_BCH
     // BCH UAHF (FORKID on txns)
-    flags |= verify_flags_script_enable_sighash_forkid;
+    if (script::is_enabled(native_forks, rule_fork::cash_verify_flags_script_enable_sighash_forkid)) {
+        flags |= verify_flags_script_enable_sighash_forkid;
+    }
 
     // Obligatory flags used on the 2017-Nov-13 BCH hard fork
     if (script::is_enabled(native_forks, rule_fork::cash_low_s_rule)) {


### PR DESCRIPTION
ForkId cash flag now activates only after the uahf height.